### PR TITLE
add_like_count_function

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,0 +1,15 @@
+class LikesController < ApplicationController
+  def create
+    @like = Like.new(like_params)
+    @like.save
+    @chord = Chord.find(@like.chord_id)
+
+    redirect_back(fallback_location: chord_path(@chord))
+  end
+
+  private
+    def like_params
+      params.permit(:chord_id).merge(user_id: current_user.id)
+    end
+
+end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,4 +1,4 @@
 class Like < ApplicationRecord
-  belongs_to :chord
+  belongs_to :chord, counter_cache: true
   belongs_to :user
 end


### PR DESCRIPTION
## what
- likeレコード登録時に、chordレコードに紐付くlike数をカウントする機能を追加

## why
- より信頼度が高いコード譜を優先的に表示するための機能。を実現するために必要な機能。