### PR TITLE
adjust_chord_change_menu

### DIFF
--- a/app/assets/javascripts/chord_change.js
+++ b/app/assets/javascripts/chord_change.js
@@ -3,7 +3,7 @@ $(function () {
 
   // キー選択パレットの表示・非表示
   //キー選択パレットを開く
-  $(".key__key-display").on("touchend mouseup", function () {
+  $(".key__key-display").on("touchend, mouseup", function () {
     $("#chord-menu").show();
     $(".wrapper").append(`<div class="clear_overlay"></div>`);
   });
@@ -20,7 +20,7 @@ $(function () {
 
   // キー表示切替
   // 絶対音
-  $(".palette--note").on("touchend mouseup", function () {
+  $(".palette--note").on("touchend, mouseup", function () {
     var selected = $(this).text().trim();
     var key_state = $(".key-display--form").val();
     console.log($("#key_name").val());
@@ -50,7 +50,7 @@ $(function () {
   });
 
   // #/b
-  $(".palette--half").on("touchend mouseup", function () {
+  $(".palette--half").on("touchend, mouseup", function () {
     var selected = $(this).text().trim();
     var key_state = $(".key-display--form").val();
 
@@ -100,7 +100,7 @@ $(function () {
   });
 
   // m
-  $(".palette--modifier").on("touchend mouseup", function () {
+  $(".palette--modifier").on("touchend, mouseup", function () {
     var key_state = $(".key-display--form").val();
 
     if (key_state.indexOf("m") == -1) {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -266,7 +266,6 @@ ul {
 
 .chord-menu__key {
   position: relative;
-  z-index: 3;
 
   &--palettes {
     border: 1px solid lightgray;
@@ -279,9 +278,10 @@ ul {
 }
 
 .key__key-display {
+  width: 80px;
   &--now {
     height: 40px;
-    width: 100px;
+    width: 100%;
 
     display: flex;
     justify-content: center;
@@ -295,7 +295,11 @@ ul {
     top: 0;
     justify-content: center;
     align-items: center;
+    z-index: 20;
   }
+}
+
+#chord-menu {
 }
 
 .palettes__section {


### PR DESCRIPTION
## what
- キーチェンジメニューの閉じる/開くボタンの範囲を調整

## why
- 開くボタンが画面横幅目いっぱいに広がっていたため、開くボタンに見えないところをタップしてもキーチェンジメニューが開くようになっていた。