### PR TITLE
change_DB_and_adjust_association

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@
 
 ### table
 
-| name     | type    | option      |
-| -------- | ------- | ----------- |
-| title    | string  | null: false |
-| jam      | boolean | null: false |
-| standard | boolean | null: false |
-| beginner | boolean | null: false |
-| user_id  | integer | null: false |
+| name         | type    | option      |
+| ------------ | ------- | ----------- |
+| title        | string  | null: false |
+| jam          | boolean | null: false |
+| standard     | boolean | null: false |
+| beginner     | boolean | null: false |
+| vocal        | boolean | null: false |
+| instrumental | boolean | null: false |
+| user_id      | integer | null: false |
 
 ### association
 
@@ -54,36 +56,36 @@
 
 ### table
 
-| name         | type    | option                   |
-| ------------ | ------- | ------------------------ |
-| song_id      | integer | null: false, foreign_key |
-| user_id      | integer | null: false, foreign_key |
-| practice_key | integer |                          |
+| name     | type    | option                   |
+| -------- | ------- | ------------------------ |
+| chord_id | integer | null: false, foreign_key |
+| user_id  | integer | null: false, foreign_key |
 
 ### asocciation
 
-- belongs_to :song
+- belongs_to :chord, counter_cache: true
 - belongs_to :user
 
 ## chord
 
 ### table
 
-| name        | type    | option                         |
-| ----------- | ------- | ------------------------------ |
-| song_id     | integer | null: false, foreign_key: true |
-| artist_id   | integer | foreign_key: true              |
-| album_id    | integer | foreign_key: true              |
-| user_id     | integer | foreign_key: true              |
-| text→delete | text    | null: false, unique: true      |
+| name           | type    | option                         |
+| -------------- | ------- | ------------------------------ |
+| song_id        | integer | null: false, foreign_key: true |
+| user_id        | integer | foreign_key: true              |
+| version        | string  |                                |
+| like_count     | integer | null: false                    |
+| practice_count | integer | null:false                     |
 
 ### asocciation
 
 - belongs_to :song
 - belongs_to :user
-- belongs_to :artist
-- belongs_to :album
+- has_many :chordunits, dependent: :destroy
+- accepts_nested_attributes_for :chordunits
 - has_many :likes, dependent: :destroy
+- has_many :practices, dependent: :destroy
 - has_many :chordunit
 
 ## chordunit
@@ -163,7 +165,7 @@
 
 ### asocciation
 
-- belongs_to :chord
+- belongs_to :chord, counter_cache: true
 - belongs_to :user
 
 ## instrument

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -17,6 +17,7 @@ $(function () {
     var beginner = $(".c-js__search-beginner").prop("checked");
     var vocal = $(".c-js__search-vocal").prop("checked");
     var instrumental = $(".c-js__search-instrumental").prop("checked");
+
     $.ajax({
       type: "get",
       url: "/songs/search",

--- a/app/models/chord.rb
+++ b/app/models/chord.rb
@@ -1,11 +1,8 @@
 class Chord < ApplicationRecord
   belongs_to :song
   belongs_to :user
-  belongs_to :artist
-  belongs_to :album
   has_many :chordunits, dependent: :destroy
   accepts_nested_attributes_for :chordunits
   has_many :likes, dependent: :destroy
-
-
+  has_many :practices, dependent: :destroy
 end

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -1,4 +1,4 @@
 class Practice < ApplicationRecord
-  belongs_to :song
   belongs_to :user
+  belongs_to :chord, counter_cache: true
 end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -1,6 +1,5 @@
 class Song < ApplicationRecord
   has_many :chords, dependent: :destroy
-  has_many :practices, dependent: :destroy
   has_many :keys, dependent: :destroy
   has_many :scores, dependent: :destroy
   belongs_to :user

--- a/db/migrate/20200616204221_add_detail_to_song.rb
+++ b/db/migrate/20200616204221_add_detail_to_song.rb
@@ -1,0 +1,6 @@
+class AddDetailToSong < ActiveRecord::Migration[5.2]
+  def change
+    add_column :songs, :vocal, :boolean, null: false
+    add_column :songs, :instrumental, :boolean, null: false
+  end
+end

--- a/db/migrate/20200616204410_add_practice_count_to_chord.rb
+++ b/db/migrate/20200616204410_add_practice_count_to_chord.rb
@@ -1,0 +1,5 @@
+class AddPracticeCountToChord < ActiveRecord::Migration[5.2]
+  def change
+    add_column :chords, :practices_count, :integer, default: 0
+  end
+end

--- a/db/migrate/20200616204955_remove_practice_key_from_practice.rb
+++ b/db/migrate/20200616204955_remove_practice_key_from_practice.rb
@@ -1,0 +1,5 @@
+class RemovePracticeKeyFromPractice < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :practices, :practice_key, :integer
+  end
+end

--- a/db/migrate/20200616205515_remove_detail_from_chord.rb
+++ b/db/migrate/20200616205515_remove_detail_from_chord.rb
@@ -1,0 +1,6 @@
+class RemoveDetailFromChord < ActiveRecord::Migration[5.2]
+  def change
+    remove_foreign_key :chords, column: :artist_id
+    remove_foreign_key :chords, column: :album_id
+  end
+end

--- a/db/migrate/20200616211446_remove_artist_id_and_album_id_from_chord.rb
+++ b/db/migrate/20200616211446_remove_artist_id_and_album_id_from_chord.rb
@@ -1,0 +1,6 @@
+class RemoveArtistIdAndAlbumIdFromChord < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :chords, :artist_id, :integer
+    remove_column :chords, :album_id, :integer
+  end
+end

--- a/db/migrate/20200616212011_remove_foreign_key_from_practice.rb
+++ b/db/migrate/20200616212011_remove_foreign_key_from_practice.rb
@@ -1,0 +1,6 @@
+class RemoveForeignKeyFromPractice < ActiveRecord::Migration[5.2]
+  def change
+    remove_foreign_key :practices, column: :song_id
+    remove_column :practices, :song_id, :integer
+  end
+end

--- a/db/migrate/20200616212537_add_references_to_practices.rb
+++ b/db/migrate/20200616212537_add_references_to_practices.rb
@@ -1,0 +1,5 @@
+class AddReferencesToPractices < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :practices, :chord, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_26_092824) do
+ActiveRecord::Schema.define(version: 2020_06_16_212537) do
 
   create_table "albums", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -28,15 +28,12 @@ ActiveRecord::Schema.define(version: 2020_05_26_092824) do
 
   create_table "chords", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "song_id"
-    t.bigint "artist_id"
-    t.bigint "album_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.string "version"
     t.integer "likes_count", default: 0
-    t.index ["album_id"], name: "index_chords_on_album_id"
-    t.index ["artist_id"], name: "index_chords_on_artist_id"
+    t.integer "practices_count", default: 0
     t.index ["song_id"], name: "index_chords_on_song_id"
     t.index ["user_id"], name: "index_chords_on_user_id"
   end
@@ -100,12 +97,11 @@ ActiveRecord::Schema.define(version: 2020_05_26_092824) do
   end
 
   create_table "practices", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "song_id"
     t.bigint "user_id"
-    t.integer "practice_key"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["song_id"], name: "index_practices_on_song_id"
+    t.bigint "chord_id"
+    t.index ["chord_id"], name: "index_practices_on_chord_id"
     t.index ["user_id"], name: "index_practices_on_user_id"
   end
 
@@ -126,6 +122,8 @@ ActiveRecord::Schema.define(version: 2020_05_26_092824) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "vocal", null: false
+    t.boolean "instrumental", null: false
     t.index ["user_id"], name: "index_songs_on_user_id"
   end
 
@@ -173,8 +171,6 @@ ActiveRecord::Schema.define(version: 2020_05_26_092824) do
   end
 
   add_foreign_key "albums", "artists"
-  add_foreign_key "chords", "albums"
-  add_foreign_key "chords", "artists"
   add_foreign_key "chords", "songs"
   add_foreign_key "chords", "users"
   add_foreign_key "chordunits", "chords"
@@ -184,7 +180,7 @@ ActiveRecord::Schema.define(version: 2020_05_26_092824) do
   add_foreign_key "keys", "songs"
   add_foreign_key "likes", "chords"
   add_foreign_key "likes", "users"
-  add_foreign_key "practices", "songs"
+  add_foreign_key "practices", "chords"
   add_foreign_key "practices", "users"
   add_foreign_key "scores", "songs"
   add_foreign_key "songs", "users"


### PR DESCRIPTION
## what
最小限機能構成において最適なDB設計に変更
- artist, albumテーブルとchordテーブルのアソシエーション解消
- practiceテーブルのアソシエーション先をsongテーブルからchordテーブルに変更
- practiceテーブルのchordテーブルとのアソシエーションにおいてcounter_cacheをtrue

## why
- いち早いリリースのため余計な機能を削除した
- 最低限の機能を実装する上で必要なカラムを追加