### PR TITLE
bugfix_for_song-registration

### DIFF
--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -103,7 +103,7 @@ class SongsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def song_params
-      params.permit(:title, :jam, :standard, :beginner, keys: [:name, :instrumental, :male, :female]).merge(user_id: current_user.id)
+      params.permit(:title, :jam, :standard, :beginner, :vocal, :instrumental).merge(user_id: current_user.id)
     end
 
 end


### PR DESCRIPTION
## what
- ストロングパラメータのpermit対象を修正

## why
- DBに新規追加したカラムについて、permitする記述になっていなかったため