### PR TITLE
add_edit-song_function

### DIFF
--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -3,30 +3,23 @@ class SongsController < ApplicationController
   before_action :authority_login, except: [:index, :show, :search]
   before_action :authority_user, only: [:edit, :update, :destroy]
 
-  # GET /songs
-  # GET /songs.json
   def index
     @songs = Song.all
   end
 
-  # GET /songs/1
-  # GET /songs/1.json
   def show
     @song = Song.find(params[:id])
   end
 
-  # GET /songs/new
   def new
     @song = Song.new
     @song.keys.build
   end
 
-  # GET /songs/1/edit
   def edit
+    @song = Song.find(params[:id])
   end
 
-  # POST /songs
-  # POST /songs.json
   def create
     @song = Song.new(song_params)
     respond_to do |format|
@@ -40,11 +33,9 @@ class SongsController < ApplicationController
     end
   end
 
-  # PATCH/PUT /songs/1
-  # PATCH/PUT /songs/1.json
   def update
     respond_to do |format|
-      if @song.update(song_params)
+      if @song.update(update_song_params)
         format.html { redirect_to @song, notice: '楽曲を更新しました' }
         format.json { render :show, status: :ok, location: @song }
       else
@@ -54,12 +45,10 @@ class SongsController < ApplicationController
     end
   end
 
-  # DELETE /songs/1
-  # DELETE /songs/1.json
   def destroy
     @song.destroy
     respond_to do |format|
-      format.html { redirect_to songs_url, notice: '楽曲を削除しました' }
+      format.html { redirect_to root_path, notice: '楽曲を削除しました' }
       format.json { head :no_content }
     end
   end
@@ -106,6 +95,11 @@ class SongsController < ApplicationController
     # Only allow a list of trusted parameters through.
     def song_params
       params.permit(:title, :jam, :standard, :beginner, :vocal, :instrumental).merge(user_id: current_user.id)
+    end
+
+        # Only allow a list of trusted parameters through.
+    def update_song_params
+      params.require(:song).permit(:title, :jam, :standard, :beginner, :vocal, :instrumental).merge(user_id: current_user.id)
     end
 
     def authority_login

--- a/app/views/songs/edit.html.haml
+++ b/app/views/songs/edit.html.haml
@@ -1,5 +1,16 @@
-%h1 Editing Song
-= render 'form', song: @song
-= link_to 'Show', @song
-|
-= link_to 'Back', songs_path
+%aside.l-contents__top.l-contents__top--low-volume.l-contents__top
+%article.c-user__position-article
+  %section.c-section__sentence-box
+    .c-song-new__logo
+      %h2 Song Edit
+      %a - 楽曲を編集する -
+    .c-song-new__form
+      =form_with url: song_path, model: @song, method: :patch, local: true do |f|
+        .c-form__area
+          =f.text_field :title, placeholder:"tittle", class:"c-form__textbox"
+        .c-form__area
+          =render "/application/song-attributes", f: f
+        .c-form__area
+          =f.submit "登録", class:"c-form__btn c-form__btn--login"
+    %figure
+      =image_tag "/images/banjo.png", class: "c-section__image-banjo"

--- a/app/views/songs/show.html.haml
+++ b/app/views/songs/show.html.haml
@@ -25,6 +25,11 @@
       .p-song__attribute.c-form__attribute.c-js__attribute{value: "#{@song.instrumental}"}
         %i.fas.fa-guitar
         %a Instrumental
+    .p-chord__manage-score
+      =link_to "Edit", edit_song_path
+      %a
+        |
+      =link_to "Delete", song_path, method: :delete
 %article.l-contents__main
   - @song.chords.each_with_index do |chord, i|
     %section.p-song__score-wrapper


### PR DESCRIPTION
## what
- songコントローラのedit, update, destroyアクションを編集
- song/editビューの作成
- songコントローラのストロングパラメータを追加(あとで１つにまとめられないか検証が必要)

## why
- songレコードの編集、削除機能追加のため