### PR TITLE
adjust_chord-display2

### DIFF
--- a/app/assets/javascripts/chord.js
+++ b/app/assets/javascripts/chord.js
@@ -1,7 +1,7 @@
 $(function () {
   // カーソル表示
-  $(".c-chordunit").on("touchend mouseup", function () {
-    $(".c-chordunit").removeClass("c-js__cursor");
+  $(".c-js__cursor-marker").on("touchend, mouseup", function () {
+    $(".c-js__cursor-marker").removeClass("c-js__cursor");
     var id = $(this).attr("id");
     $("#" + id).addClass("c-js__cursor");
 
@@ -60,9 +60,9 @@ $(function () {
       $(".c-js__cursor > .c-chordunit__" + unit_name).text(input);
     }
 
-    $(
-      ".c-js__cursor > #chord_chordunits_attributes_" + id + "_" + unit_name
-    ).val($(".c-js__cursor > .c-chordunit__" + unit_name).text());
+    $("#chord_chordunits_attributes_" + id + "_" + unit_name).val(
+      $(".c-js__cursor > .c-chordunit__" + unit_name).text()
+    );
   }
 
   // 音名の入力処理
@@ -161,9 +161,11 @@ $(function () {
   function input_text_display(unit_id) {
     $(".c-chord-edit__text-window").text("");
 
-    var get_input = $("#" + unit_id)
-      .find(".c-chordunit__text")
-      .attr("value");
+    unit_id = unit_id.replace("unit_0-", "");
+
+    var get_input = $("#chord_chordunits_attributes_" + unit_id + "_text").attr(
+      "value"
+    );
 
     $(".c-chord-edit__text-window").text(get_input);
   }

--- a/app/assets/stylesheets/object/component/_chordunit.scss
+++ b/app/assets/stylesheets/object/component/_chordunit.scss
@@ -24,6 +24,9 @@
   }
 
   &--small {
+    font-size: 18px;
+    position: absolute;
+    left: -6px;
   }
 }
 .c-chordunit__leftbar {

--- a/app/assets/stylesheets/object/component/_form.scss
+++ b/app/assets/stylesheets/object/component/_form.scss
@@ -68,6 +68,7 @@
 }
 
 .c-form__btn {
+  cursor: pointer;
   height: 27px;
   width: 45px;
   border-radius: 5px;

--- a/app/views/chords/edit.html.haml
+++ b/app/views/chords/edit.html.haml
@@ -25,14 +25,18 @@
 
       .p-song__score
         -48.times do |i|
-          .c-chordunit.c-chordunit--large{id: "unit_0-#{i}"}
+          .c-chordunit.c-js__cursor-marker.c-chordunit--large{id: "unit_0-#{i}"}
             .c-chordunit__beat.c-chordunit__beat--large
+              =@chord.chordunits[i].beat
             .c-chordunit__leftbar.c-chordunit__leftbar--large
+              =@chord.chordunits[i].leftbar
             .c-chordunit__note
               .c-chordunit__note-name.c-chordunit__note-name--large
               .c-chordunit__half-note.c-chordunit__half-note--large
               .c-chordunit__modifier.c-chordunit__modifier--large
             .c-chordunit__rightbar.c-chordunit__rightbar--large
+              =@chord.chordunits[i].rightbar
+
       =f.fields_for :chordunits do |unit_f|
         =unit_f.hidden_field :address
         =unit_f.hidden_field :text, class: "c-chordunit__text"

--- a/app/views/chords/new.html.haml
+++ b/app/views/chords/new.html.haml
@@ -26,7 +26,7 @@
 
       .p-song__score
         -48.times do |i|
-          .c-chordunit.c-chordunit--large{id: "unit_0-#{i}"}
+          .c-chordunit.c-js__cursor-marker.c-chordunit--large{id: "unit_0-#{i}"}
             .c-chordunit__beat.c-chordunit__beat--large
             .c-chordunit__leftbar.c-chordunit__leftbar--large
             .c-chordunit__note


### PR DESCRIPTION
## what
- viewファイルのクラス割り当ての修正
- javascriptのセレクタと値の取得メソッドの書き換え
- cssの微修正

## why
- コード譜の編集画面以外でカーソルが表示される問題を修正
- 選択中のchordunitのtextデータをユーザに表示する機能が新規作成画面のみで適用されていたものを編集画面にも反映
- バグフィックス、UIの僅かな向上