### PR TITLE
Adjust validation and add error message

### DIFF
--- a/app/assets/stylesheets/layout/_header.scss
+++ b/app/assets/stylesheets/layout/_header.scss
@@ -46,7 +46,7 @@
   // layout
   width: 100vw;
   position: fixed;
-  z-index: 65;
+  z-index: 100;
   top: 0px;
 
   // design

--- a/app/assets/stylesheets/object/project/_user.scss
+++ b/app/assets/stylesheets/object/project/_user.scss
@@ -34,11 +34,12 @@
 .p-user__info-list {
   height: 28px;
   display: flex;
-  align-items: flex-end;
+  align-items: center;
+  margin-bottom: 5px;
 }
 
 .p-user__info-item {
-  width: 50px;
+  width: 80px;
 }
 
 .p-user__info-data {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
     end
 
     def configure_permitted_parameters
-      devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :place])
     end
 
     def authority_login
@@ -27,7 +27,7 @@ class ApplicationController < ActionController::Base
     end
 
     def authority_user
-      if (current_user.id == @user.id) | (current_user.admin == 1)
+      if current_user.id == @user.id || current_user.admin.present?
       else
         redirect_back fallback_location: root_path, notice: 'あなたが作成したデータではありません。'
       end

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -4,8 +4,6 @@ class SongsController < ApplicationController
   before_action :authority_login, only: [:edit, :update, :destroy]
   before_action :authority_user, only: [:edit, :update, :destroy]
 
-
-
   def index
     @songs = Song.all
   end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -65,7 +65,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def test_user_protection
-    redirect_back fallback_location: root_path, notice: 'テストユーザーは編集できません'
+    if User.test_user_find.id == current_user.id || current_user.admin.present?
+      redirect_back fallback_location: root_path, notice: 'テストユーザーは編集できません'
+    end
   end
 
   # The path used after sign up for inactive accounts.

--- a/app/models/chord.rb
+++ b/app/models/chord.rb
@@ -1,5 +1,4 @@
 class Chord < ApplicationRecord
-
   belongs_to :song
   belongs_to :user
   has_many :chordunits, dependent: :destroy

--- a/app/models/chord.rb
+++ b/app/models/chord.rb
@@ -1,4 +1,8 @@
 class Chord < ApplicationRecord
+  validates :version, length: {maximum: 50, message: "は50文字以内で設定してください"}
+  validates :key, length: {in: 1..3, message: "は20文字以内で設定してください：システムエラー：管理者に連絡してください"}
+  validates_associated :chordunits
+
   belongs_to :song
   belongs_to :user
   has_many :chordunits, dependent: :destroy

--- a/app/models/chordunit.rb
+++ b/app/models/chordunit.rb
@@ -1,3 +1,6 @@
 class Chordunit < ApplicationRecord
+  validates :address, presence: {message: "がコードノートデータに含まれておりません：フォームエラー：管理者に連絡してください"}
+  validates :text, length: {maximum: 20, message: "の文字数は20文字以内にしてください"}
+  validates :beat, :leftbar, :rightbar, length: {maximum: 1, message: "は2文字以上に設定しないでください：システムエラー：管理者に連絡してください"}
   belongs_to :chord
 end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -1,10 +1,9 @@
 class Song < ApplicationRecord
-  validates :title, uniqueness: {case_sensitive: false, message: "%{value}は既に登録されています"}
-  validates :title, presence: {message: "タイトルを入力してください"}
+  validates :title, uniqueness: {case_sensitive: false, message: ":%{value}は既に登録されています"}
+  validates :title, presence: {message: "を入力してください"}
+  validates :title, length: {in: 2..50, message: "は2~50文字に設定してください"}
 
   has_many :chords, dependent: :destroy
-  has_many :scores, dependent: :destroy
-  has_many :practices, dependent: :destroy
+  has_many :practice_songs, dependent: :destroy
   belongs_to :user
-
 end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -1,6 +1,6 @@
 class Song < ApplicationRecord
-
-  validates :title, presence: true, uniqueness: {case_sensitive: false}
+  validates :title, uniqueness: {case_sensitive: false, message: "%{value}は既に登録されています"}
+  validates :title, presence: {message: "タイトルを入力してください"}
 
   has_many :chords, dependent: :destroy
   has_many :scores, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  validates :name, presence: {message: "が空欄です"}
+  validates :email, uniqueness: {case_sensitive: false, message: "は既に登録されています"}
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,18 +1,23 @@
 class User < ApplicationRecord
   validates :name, presence: {message: "が空欄です"}
+  validates :name, length: {in: 2..40, message: "は2~40文字に設定してください"}
   validates :email, uniqueness: {case_sensitive: false, message: "は既に登録されています"}
+  validates :email, length: {in: 3..254, message: "は254文字以内のものを登録してください"}
+  validates :place, length: {maximum: 50, message: "は50文字以内に設定してください"}
+  validates :admin, exclusion: {in: [true]}
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  has_many :songs
   has_many :chords
   has_many :likes, dependent: :destroy
   has_many :practices, dependent: :destroy
-  has_many :practices, dependent: :destroy
+  has_many :practice_songs, dependent: :destroy
 
   def self.test_user_find
-    self.find_by(name: "テストユーザー")
+    self.find_by(id: "0")
   end
 
 end

--- a/app/views/chords/show.html.haml
+++ b/app/views/chords/show.html.haml
@@ -4,7 +4,7 @@
       %h2
         =@chord.song.title
       .p-chord__key
-        = "key of "+@chord.key 
+        = "key of "+@chord.key
     .p-chord__review
       =render "/application/review", chord: @chord
     .p-chord__info
@@ -26,7 +26,7 @@
               %a{class: "font_base-key c-font__base"}
                 = @chord.key[1]
             - else
-              = "key of " + @chord.key 
+              = "key of " + @chord.key
         =render "/application/key-change"
       .c-key-change__guide << key change!!
       .c-key-change__close-layer
@@ -39,6 +39,6 @@
       =link_to "Edit", edit_chord_path
       %a
         |
-      =link_to "Delete", chord_path, method: :delete
+      =link_to "Delete", chord_path, method: :delete, data: { confirm: "本当によろしいですか？" }
   .p-chord__return
     =link_to "コード譜一覧に戻る", song_path(@chord.song)

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -22,7 +22,11 @@
           %span
           %span
           %span
-    %p.l-header__notice= notice
+
+    %p.l-header__notice= flash[:error]
+    %p.l-header__notice= flash[:alert]
+    %p.l-header__notice= flash[:notice]
+
     .l-contents
       %main.l-main
         =yield

--- a/app/views/songs/edit.html.haml
+++ b/app/views/songs/edit.html.haml
@@ -7,7 +7,7 @@
     .c-song-new__form
       =form_with url: song_path, model: @song, method: :patch, local: true do |f|
         .c-form__area
-          =f.text_field :title, placeholder:"tittle", class:"c-form__textbox"
+          =f.text_field :title, placeholder:"タイトル", class:"c-form__textbox"
         .c-form__area
           =render "/application/song-attributes", f: f, collection: @song
         .c-form__area

--- a/app/views/songs/new.html.haml
+++ b/app/views/songs/new.html.haml
@@ -7,11 +7,11 @@
     .c-song-new__form
       =form_with url:songs_path, method: :post, local: true do |f|
         .c-form__area
-          =f.text_field :title, autocomplete:"off", placeholder:"tittle", class:"c-form__textbox"
+          =f.text_field :title, autocomplete:"off", placeholder:"タイトル", class:"c-form__textbox"
         .c-form__area
           =render "/application/song-attributes", f: f
         .c-form__area
           =f.submit "登録", class:"c-form__btn c-form__btn--login"
-    
+
     %figure
       =image_tag "/images/banjo.png", class: "c-section__image-banjo"

--- a/app/views/songs/show.html.haml
+++ b/app/views/songs/show.html.haml
@@ -29,7 +29,7 @@
       =link_to "Edit", edit_song_path
       %a
         |
-      =link_to "Delete", song_path, method: :delete
+      =link_to "Delete", song_path, method: :delete, data: { confirm: "本当によろしいですか？" }
 %article.l-contents__main
   - @chords.each_with_index do |chord, i|
     %section.p-song__score-wrapper

--- a/app/views/users/registrations/edit.html.haml
+++ b/app/views/users/registrations/edit.html.haml
@@ -7,11 +7,11 @@
     .c-user__form
       =form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
         .c-form__area
-          =f.text_field :name, placeholder:"name", class:"c-form__textbox c-user__textbox"
-          =f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "email", class:"c-form__textbox c-user__textbox"
+          =f.text_field :name, placeholder:"名前", class:"c-form__textbox c-user__textbox"
+          =f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メール", class:"c-form__textbox c-user__textbox"
           %a (#{@minimum_password_length} characters minimum)
           =f.password_field :password, autocomplete: "new-password", placeholder: "パスワード", class:"c-form__textbox c-user__textbox"
-          =f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "パスワード(確認用)", class:"c-form__textbox c-user__textbox"
+          =f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "パスワード(確認)", class:"c-form__textbox c-user__textbox"
           =f.password_field :current_password, autocomplete: "current-password", placeholder: "現在のパスワード", class:"c-form__textbox c-user__textbox"
         .c-form__area
           =f.submit "登録", class:"c-form__btn c-form__btn--login"

--- a/app/views/users/registrations/edit.html.haml
+++ b/app/views/users/registrations/edit.html.haml
@@ -8,6 +8,7 @@
       =form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
         .c-form__area
           =f.text_field :name, placeholder:"名前", class:"c-form__textbox c-user__textbox"
+          =f.text_field :place, placeholder: "主な活動地域", class:"c-form__textbox c-user__textbox"
           =f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メール", class:"c-form__textbox c-user__textbox"
           %a (#{@minimum_password_length} characters minimum)
           =f.password_field :password, autocomplete: "new-password", placeholder: "パスワード", class:"c-form__textbox c-user__textbox"

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -1,3 +1,6 @@
+- @user.errors.full_messages.each do |msg|
+  %p.l-header__notice
+    =msg
 %aside.l-contents__top.l-contents__top--low-volume.l-contents__top--sub
 %article.c-user__position-article
   %section.c-section__sentence-box
@@ -7,11 +10,11 @@
     .c-user__form
       =form_for(resource, as: resource_name, url: registration_path(resource_name))  do |f|
         .c-form__area
-          =f.text_field :name, placeholder:"name", class:"c-form__textbox c-user__textbox"
-          =f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "email", class:"c-form__textbox c-user__textbox"
+          =f.text_field :name, placeholder:"名前", class:"c-form__textbox c-user__textbox"
+          =f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メール", class:"c-form__textbox c-user__textbox"
           %a (#{@minimum_password_length} characters minimum)
-          =f.password_field :password, autocomplete: "new-password", placeholder: "password", class:"c-form__textbox c-user__textbox"
-          =f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "password(確認)", class:"c-form__textbox c-user__textbox"
+          =f.password_field :password, autocomplete: "new-password", placeholder: "パスワード", class:"c-form__textbox c-user__textbox"
+          =f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "パスワード(確認)", class:"c-form__textbox c-user__textbox"
         .c-form__area
           =f.submit "登録", class:"c-form__btn c-form__btn--login"
     %figure

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -11,6 +11,8 @@
       =form_for(resource, as: resource_name, url: registration_path(resource_name))  do |f|
         .c-form__area
           =f.text_field :name, placeholder:"名前", class:"c-form__textbox c-user__textbox"
+          =f.text_field :place, placeholder: "主な活動地域", class:"c-form__textbox c-user__textbox"
+
           =f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メール", class:"c-form__textbox c-user__textbox"
           %a (#{@minimum_password_length} characters minimum)
           =f.password_field :password, autocomplete: "new-password", placeholder: "パスワード", class:"c-form__textbox c-user__textbox"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -12,14 +12,18 @@
         基本情報
     .p-user__section-content
       .p-user__info-list
-        .p-user__info-item name:
+        .p-user__info-item 名前:
         .p-user__info-data
           = @user.name
       - if @user.id == current_user.id
         .p-user__info-list
-          .p-user__info-item email:
+          .p-user__info-item メール:
           .p-user__info-data.p-user__info-data--email
             = @user.email
+      .p-user__info-list
+        .p-user__info-item 活動拠点:
+        .p-user__info-data
+          = @user.place
     .p-user__section-footer
       .p-user__review_icon.c-review__btn
         .c-review__icon

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,6 +6,14 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
+    attributes:
+      song:
+        title: ""
+      user:
+        name: 名前
+        email: そのメールアドレス
+        password: パスワード
+        password_confirmation: 確認用のパスワード
   date:
     abbr_day_names:
       - 日

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,8 +7,16 @@ ja:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
     attributes:
+      chord:
+        version: "バージョン名"
+      chordunit:
+        address: "アドレスデータ"
+        text: "テキストデータ(エディターの編集ウィンドウに表示される文字列)"
+        beat: "拍子記号"
+        leftbar: "終始線(左)"
+        rightbar: "終始線(右)"
       song:
-        title: ""
+        title: "タイトル"
       user:
         name: 名前
         email: そのメールアドレス


### PR DESCRIPTION
①push1
## what
- song, userクラスのモデルにバリデーションの記述を追記。
- 上記バリデーションについて、エラーメッセージを追加
- user作成ビューにエラーメッセージを表示するための記述を追加※
※他モデルにおいては、flashインスタンスをビュー上に表示する記述があればエラーメッセージが表示される。user(deviseを利用)においても、ネットの文献を参考にする限り、共用できるはずだが、うまく動作しなかった。このためDRYではないが、user/registrations/new.html.hamlについては特別に記述を追加している。

## why
- データ登録時、記載データが不十分だとデータが登録されない（フェールセーフ）
- データ登録に失敗した時に、原因をユーザに通知する

②push2
## what
- chord, chordunit, song, userモデルにバリデーションを設定
- 同バリデーションエラー時に表示されるメッセージを設定
- locale/jaに各カラムの日本語訳を設定
- registration/new, editビューにplaceカラムに関するフォームを追加
- devise sanitizer(ストロングパラメータ)にplace属性を追加
- song, chordに関するビュー中の削除ボタンに確認メッセージを追加
- registrationコントローラのtest_user_protectionのif条件が不適切だったため修正
- その他 軽微なバグフィックス、リファクタリング
※like, practice, practice_songモデルのバリデーションについては検討の結果、バリデーションの記述不要と判断

## why
- フェールセーフのためのバリデーションを追加
- ビュー以外の正統でないアクセスへの対策としてのバリデーションを追加
- userテーブルのplaceカラムのデータを操作、表示する機能を追加
- songデータ削除時のエラーを修正
- 「テストユーザ」を保護するためのメソッドの内容を修正