### PR TITLE
add_db_migrate_to_CD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,14 +17,15 @@ RUN apk update && \
     gem install bundler && \
     bundle install -j4 --without development test && \
     rm -rf /usr/local/bundle/cache/*.gem && \
-    rm -rf /root/.bundle/cache/* && \
     rm -rf /usr/local/bundle/ruby/2.5.0/cache/* && \
+    rm -rf /root/.bundle/cache/* && \
+    find /usr/lib/node_modules -delete && \
     find /usr/local/bundle/gems/ -name "*.c" -delete && \
     find /usr/local/bundle/gems/ -name "*.o" -delete && \
-    find /usr/lib/node_modules -delete && \
     apk del --purge libxml2-dev curl-dev make gcc libc-dev g++ linux-headers && \
     bundle exec rails assets:precompile RAILS_ENV=production && \
     find /usr/local/bundle/ruby/2.5.0/gems/sassc-2.3.0 -name "*" -delete
 
 COPY . /grasschords
-# RUN find /grasschords/tmp/cache -name "*" -delete
+RUN chmod +x start.sh
+CMD ["/grasschords/start.sh"]

--- a/app/assets/javascripts/chord.js
+++ b/app/assets/javascripts/chord.js
@@ -108,7 +108,7 @@ $(function () {
     // 音名処理、１列目に存在するときのみ反映
     if (note_name_array.includes(letter_array[i])) {
       if (letter_array[i] == "‘") {
-        var html = `<span class="font_repeat">‘</span>`;
+        var html = `<span class="c-font__repeat">‘</span>`;
         $(
           "#" + unit_id + " > .c-chordunit__note > .c-chordunit__note-name"
         ).append(html);

--- a/db/migrate/20200822054404_add_image_to_user.rb
+++ b/db/migrate/20200822054404_add_image_to_user.rb
@@ -1,0 +1,5 @@
+class AddImageToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :image, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_04_121132) do
+ActiveRecord::Schema.define(version: 2020_08_22_054404) do
 
-  create_table "artists", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
-    t.string "name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "chords", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "chords", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "song_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -31,7 +25,7 @@ ActiveRecord::Schema.define(version: 2020_07_04_121132) do
     t.index ["user_id"], name: "index_chords_on_user_id"
   end
 
-  create_table "chordunits", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "chordunits", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "address", null: false
     t.text "text"
     t.string "leftbar"
@@ -43,18 +37,7 @@ ActiveRecord::Schema.define(version: 2020_07_04_121132) do
     t.index ["chord_id"], name: "index_chordunits_on_chord_id"
   end
 
-  create_table "keys", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
-    t.string "name", null: false
-    t.boolean "instrumental", null: false
-    t.boolean "male", null: false
-    t.boolean "female", null: false
-    t.bigint "song_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["song_id"], name: "index_keys_on_song_id"
-  end
-
-  create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "chord_id"
     t.bigint "user_id"
     t.datetime "created_at", null: false
@@ -63,7 +46,7 @@ ActiveRecord::Schema.define(version: 2020_07_04_121132) do
     t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
-  create_table "practice_songs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "practice_songs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "song_id"
     t.bigint "user_id"
     t.datetime "created_at", null: false
@@ -72,7 +55,7 @@ ActiveRecord::Schema.define(version: 2020_07_04_121132) do
     t.index ["user_id"], name: "index_practice_songs_on_user_id"
   end
 
-  create_table "practices", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "practices", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -83,7 +66,7 @@ ActiveRecord::Schema.define(version: 2020_07_04_121132) do
     t.index ["user_id"], name: "index_practices_on_user_id"
   end
 
-  create_table "songs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "songs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title", null: false
     t.boolean "jam", null: false
     t.boolean "standard", null: false
@@ -97,7 +80,7 @@ ActiveRecord::Schema.define(version: 2020_07_04_121132) do
     t.index ["user_id"], name: "index_songs_on_user_id"
   end
 
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "place"
     t.string "email", default: "", null: false
@@ -108,6 +91,7 @@ ActiveRecord::Schema.define(version: 2020_07_04_121132) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "admin", default: false
+    t.string "image", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
@@ -115,7 +99,6 @@ ActiveRecord::Schema.define(version: 2020_07_04_121132) do
   add_foreign_key "chords", "songs"
   add_foreign_key "chords", "users"
   add_foreign_key "chordunits", "chords"
-  add_foreign_key "keys", "songs"
   add_foreign_key "likes", "chords"
   add_foreign_key "likes", "users"
   add_foreign_key "practice_songs", "songs"

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+rails db:create RAILS_ENV=production
+rails db:migrate RAILS_ENV=production
+bundle exec unicorn -p 3000 -c /grasschords/config/unicorn.rb -E production


### PR DESCRIPTION
## what
- shellファイルを追加
- Dockerfileに上記のshellファイルを叩く記述を追加
- userテーブルにimageカラムを追加するファイルを追加

## why
- CI/CDにrails db:migrateを行う工程が入っておらず、テーブルを変更するたびに本番環境のDBサーバにログインしなければならない仕様だった。改善することでこの作業を省略することができる
- テストも兼ねて、ユーザのプロフィール画像設定機能の実装のためのカラムを追加