### PR TITLE
fix_user_registration_error

### DIFF
--- a/app/assets/javascripts/recaptcha.js
+++ b/app/assets/javascripts/recaptcha.js
@@ -1,15 +1,16 @@
 $(function () {
   $("#new_user").on("submit", function (e) {
     e.preventDefault();
-
+    console.log("hakka");
     grecaptcha.ready(function () {
       grecaptcha
         .execute("6LdDibUZAAAAAB3YKCwEDjWuSwzOM86evQRvjWah", {
           action: "submit",
         })
         .then(function (token) {
-          // Add your logic to submit to your backend server here.
           console.log(token);
+
+          // Add your logic to submit to your backend server here.
           $(".c-js__recaptcha-token").val(token);
           // フォーム送信
           $("#new_user").off("submit");

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,7 +2,6 @@
 require "uri"
 require "net/http"
 require "json"
-
 class Users::SessionsController < Devise::SessionsController
   include UsersHelper
   before_action :test_user_call, only: [:test_create]

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -4,7 +4,6 @@ module UsersHelper
   # end
 
   def get_recaptcha_response(token)
-    # binding.pry
     siteverify_uri = URI.parse("https://www.google.com/recaptcha/api/siteverify?response=#{token}&secret=#{Rails.application.credentials.recaptcha[:recaptcha_secret_key]}")
     response = Net::HTTP.get_response(siteverify_uri)
     json_response = JSON.parse(response.body)

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -1,3 +1,4 @@
+%script{src: "https://www.google.com/recaptcha/api.js?render=6LdDibUZAAAAAB3YKCwEDjWuSwzOM86evQRvjWah"}
 - @user.errors.full_messages.each do |msg|
   %p.l-header__notice
     =msg
@@ -12,12 +13,11 @@
         .c-form__area
           =f.text_field :name, placeholder:"名前", class:"c-form__textbox c-user__textbox"
           =f.text_field :place, placeholder: "主な活動地域", class:"c-form__textbox c-user__textbox"
-
           =f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メール", class:"c-form__textbox c-user__textbox"
-          %a (#{@minimum_password_length} characters minimum)
           =f.password_field :password, autocomplete: "new-password", placeholder: "パスワード", class:"c-form__textbox c-user__textbox"
           =f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "パスワード(確認)", class:"c-form__textbox c-user__textbox"
+          =f.hidden_field :token, class: "c-js__recaptcha-token"
         .c-form__area
-          =f.submit "登録", class:"c-form__btn c-form__btn--login"
+          =f.submit "登録", class:"c-form__btn c-form__btn--login c-js__recaptcha"
     %figure
       =image_tag "/images/fiddle.png", class: "c-section__image-fiddle"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,7 +19,7 @@ ja:
         title: "タイトル"
       user:
         name: 名前
-        email: そのメールアドレス
+        email: メールアドレス
         password: パスワード
         password_confirmation: 確認用のパスワード
   recaptcha:

--- a/spec/controllers/users_registrations_controller_spec.rb
+++ b/spec/controllers/users_registrations_controller_spec.rb
@@ -6,6 +6,13 @@ RSpec.describe Users::RegistrationsController, type: :controller do
     @test_user = FactoryBot.create(:user, id: 0, name: "Ralph Stanley")
   end
   describe "registrations#create" do
+    before do
+      response_mock = Net::HTTPOK.new(nil, 200, "OK")
+      http_obj = double("Net::HTTP")
+      recaptcha_mock = '{ "success": true, "challenge_ts": "2020-08-01T03:00:35Z", "hostname": "localhost", "score": 0.9, "action": "submit"}'
+      allow(Net::HTTP).to receive(:get_response).and_return(response_mock)
+      allow(response_mock).to receive(:body).and_return(recaptcha_mock)
+    end
     it "userレコードを登録できる" do
       user_params = FactoryBot.attributes_for(:user)
       expect{

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -34,29 +34,39 @@ RSpec.feature "Users", type: :feature do
     expect(page).to_not have_content "マイページ"
     expect(page).to_not have_content "データ作成"
   end
-  scenario "ユーザ登録" do
-    user = FactoryBot.build(:user)
-    visit root_path
+  context do
+    before do
+      response_mock = Net::HTTPOK.new(nil, 200, "OK")
+      http_obj = double("Net::HTTP")
+      recaptcha_mock = '{ "success": true, "challenge_ts": "2020-08-01T03:00:35Z", "hostname": "localhost", "score": 0.9, "action": "submit"}'
+      allow(Net::HTTP).to receive(:get_response).and_return(response_mock)
+      allow(response_mock).to receive(:body).and_return(recaptcha_mock)
+    end
+    scenario "ユーザ登録" do
 
-    expect(page).to_not have_content "マイページ"
-    expect(page).to_not have_content "データ作成"
+      user = FactoryBot.build(:user)
+      visit root_path
 
-    expect{
-    click_link "ユーザ登録"
+      expect(page).to_not have_content "マイページ"
+      expect(page).to_not have_content "データ作成"
 
-    fill_in "名前", with: user.name
-    fill_in "主な活動地域", with: user.place
-    fill_in "メール", with: user.email
-    fill_in "パスワード", with: user.password
-    fill_in "パスワード(確認)", with: user.password
+      expect{
+      click_link "ユーザ登録"
 
-    click_button "登録"
+      fill_in "名前", with: user.name
+      fill_in "主な活動地域", with: user.place
+      fill_in "メール", with: user.email
+      fill_in "パスワード", with: user.password
+      fill_in "パスワード(確認)", with: user.password
 
-    expect(page).to have_current_path(root_path)
-    expect(page).to have_content "ようこそ！ アカウントが登録されました"
-    expect(page).to have_content "マイページ"
-    expect(page).to have_content "データ作成"
-  }.to change(User, :count).by(1)
+      click_button "登録"
+
+      expect(page).to have_current_path(root_path)
+      expect(page).to have_content "ようこそ！ アカウントが登録されました"
+      expect(page).to have_content "マイページ"
+      expect(page).to have_content "データ作成"
+    }.to change(User, :count).by(1)
+    end
   end
 
   scenario "ユーザー情報の編集・削除" do


### PR DESCRIPTION
## what
- users/registration#createにrecaptchaに関わる記述を追加
-
- rspecテストの修正
- その他 不要な記述の削除

## why
- ユーザ登録機能にもrecaptchaを導入
- 上記に対応するため、モックの記述を追加