### PR TITLE
add_shift_&_backspace_icon_to_chord_editor

### DIFF
--- a/app/assets/stylesheets/object/component/_chord-edit.scss
+++ b/app/assets/stylesheets/object/component/_chord-edit.scss
@@ -51,8 +51,12 @@
   color: $color-font-white;
 }
 
-.c-chord-edit__size-backspace {
+.c-chord-edit__size-shift {
   width: calc(28% - 14px);
+  display: flex;
+}
+.c-chord-edit__icon {
+  margin-right: 4px;
 }
 
 .c-chord-edit__blank {

--- a/app/views/application/_chord-editor.html.haml
+++ b/app/views/application/_chord-editor.html.haml
@@ -34,7 +34,8 @@
       .c-chord-edit__btn
         .c-chord-edit__blank
         .c-chord-edit__input.c-font__base.c-js__chord-editor-duplication '
-      .c-chord-edit__btn.c-chord-edit__size-backspace
+      .c-chord-edit__btn.c-chord-edit__size-shift
+        %i.far.fa-caret-square-up.c-chord-edit__icon
         .c-chord-edit__input Shift
       .c-chord-edit__btn
         .c-chord-edit__input.c-font__base {
@@ -49,7 +50,8 @@
         .c-chord-edit__blank
         .c-chord-edit__input.c-font__base ]
       .c-chord-edit__btn
-        .c-chord-edit__input BS
+        .c-chord-edit__input.u-display__hidden BS
+        %i.fas.fa-backspace
 .c-chord-edit__wrapper.c-chord-edit__wrapper--2nd.c-window__clear-black.u-display__hidden
   .c-chord-edit__editor
     .c-chord-edit__sub
@@ -86,7 +88,8 @@
       .c-chord-edit__btn
         .c-chord-edit__blank
         .c-chord-edit__input.c-font__base.c-js__chord-editor-duplication  "
-      .c-chord-edit__btn.c-chord-edit__size-backspace
+      .c-chord-edit__btn.c-chord-edit__size-shift
+        %i.far.fa-caret-square-up.c-chord-edit__icon
         .c-chord-edit__input Shift
       .c-chord-edit__btn
         .c-chord-edit__input.c-font__base.c-font__size-base @
@@ -97,4 +100,5 @@
       .c-chord-edit__btn
         .c-chord-edit__input.c-font__base.c-font__size-base P
       .c-chord-edit__btn
-        .c-chord-edit__input BS
+        .c-chord-edit__input.u-display__hidden BS
+        %i.fas.fa-backspace


### PR DESCRIPTION
## what
- コードエディターのbackspaceボタンをアイコンに変更
- コードエディターのshiftボタンにアイコンを追加

## why
- UI改善