### PR TITLE
add_next_chordunit_key_to_chord_editor

### DIFF
--- a/app/assets/javascripts/chord.js
+++ b/app/assets/javascripts/chord.js
@@ -71,14 +71,22 @@ $(function () {
       return false;
     }
     var id = $(".c-js__cursor").attr("id");
+
     id = id.replace("unit_0-", "");
 
-    // if some of command duplicates, under below judge statement resolves this problem.
+    if (input == "next") {
+      id = Number(id) + 1;
+      id = "unit_0-" + id;
+      cursor_display(id);
+      return false;
+    }
+
     if (
       $(this)
         .find(".c-chord-edit__input")
         .hasClass("c-js__chord-editor-duplication")
     ) {
+      // if some of command duplicates, under below judge statement resolves this problem.
       if (input == "B") input = "sharp";
       else if (input == "'") input = "rbar";
       else if (input == '"') input = "rwbar";
@@ -136,7 +144,6 @@ $(function () {
       .find(".c-chordunit__" + unit_name);
     var insertHTML = change_input_to_HTML(unit_name, input);
 
-    console.log(insertHTML);
     if (selected_element.html().includes(insertHTML)) {
       // same value has input
       selected_element.children().remove(":contains('" + input + "')");

--- a/app/assets/stylesheets/foundation/_base.scss
+++ b/app/assets/stylesheets/foundation/_base.scss
@@ -2,7 +2,7 @@ $color-theme-red: #a64951;
 $color-accent-gold: #a6a149;
 $color-accent-blue: #4997a6;
 $color-dark-brown: #593831;
-$color-font-black: #333333;
+$color-font-black: #222222;
 $color-font-white: #ffffff;
 $color-btn-normal: #c4c4c4;
 $color-icon-gray: #929292;

--- a/app/assets/stylesheets/object/component/_chord-edit.scss
+++ b/app/assets/stylesheets/object/component/_chord-edit.scss
@@ -49,14 +49,13 @@
   // design
   box-shadow: 4px 4px 4px rgba(0, 0, 0, 0.3);
   color: $color-font-white;
+  cursor: pointer;
+  touch-action: manipulation;
 }
 
 .c-chord-edit__size-shift {
   width: calc(28% - 14px);
   display: flex;
-}
-.c-chord-edit__icon {
-  margin-right: 4px;
 }
 
 .c-chord-edit__blank {

--- a/app/views/application/_chord-editor.html.haml
+++ b/app/views/application/_chord-editor.html.haml
@@ -34,9 +34,9 @@
       .c-chord-edit__btn
         .c-chord-edit__blank
         .c-chord-edit__input.c-font__base.c-js__chord-editor-duplication '
-      .c-chord-edit__btn.c-chord-edit__size-shift
+      .c-chord-edit__btn
         %i.far.fa-caret-square-up.c-chord-edit__icon
-        .c-chord-edit__input Shift
+        .c-chord-edit__input.u-display__hidden Shift
       .c-chord-edit__btn
         .c-chord-edit__input.c-font__base {
         .c-chord-edit__blank
@@ -49,6 +49,9 @@
       .c-chord-edit__btn
         .c-chord-edit__blank
         .c-chord-edit__input.c-font__base ]
+      .c-chord-edit__btn
+        %i.fas.fa-arrow-circle-right
+        .c-chord-edit__input.u-display__hidden next
       .c-chord-edit__btn
         .c-chord-edit__input.u-display__hidden BS
         %i.fas.fa-backspace
@@ -86,9 +89,9 @@
       .c-chord-edit__btn
         .c-chord-edit__blank
         .c-chord-edit__input.c-font__base.c-js__chord-editor-duplication  "
-      .c-chord-edit__btn.c-chord-edit__size-shift
-        %i.far.fa-caret-square-up.c-chord-edit__icon
-        .c-chord-edit__input Shift
+      .c-chord-edit__btn
+        %i.far.fa-caret-square-up
+        .c-chord-edit__input.u-display__hidden Shift
       .c-chord-edit__btn
         .c-chord-edit__input.c-font__base.c-font__size-base @
       .c-chord-edit__btn
@@ -97,6 +100,9 @@
         .c-chord-edit__input.c-font__base.c-font__size-base #
       .c-chord-edit__btn
         .c-chord-edit__input.c-font__base.c-font__size-base P
+      .c-chord-edit__btn
+        %i.fas.fa-arrow-circle-right
+        .c-chord-edit__input.u-display__hidden next
       .c-chord-edit__btn
         .c-chord-edit__input.u-display__hidden BS
         %i.fas.fa-backspace

--- a/spec/features/chords_spec.rb
+++ b/spec/features/chords_spec.rb
@@ -73,6 +73,12 @@ RSpec.feature "Chords", type: :feature do
 
       expect(find(".c-chord-edit__text-window")).to have_content "Abm7B"
 
+
+      all(".c-chord-edit__btn")[19].click   # next
+      all(".c-chord-edit__btn")[5].click    # E
+
+      expect(all(".c-chordunit__note-name")[1]).to have_content "E"
+
       find(".c-chord-edit__close").click
       all(".c-chordunit")[$chordunit_num-1].click
       find(".p-chord-new__editor-btn").click
@@ -100,7 +106,7 @@ RSpec.feature "Chords", type: :feature do
       all(".c-chord-edit__btn")[11].click   # 2nd-shift
 
       all(".c-chord-edit__btn")[4].click    # D
-      all(".c-chord-edit__btn")[19].click   # BackSpace
+      all(".c-chord-edit__btn")[20].click   # BackSpace
 
 
       expect(find(".c-chord-edit__text-window")).to have_content "Cssm"
@@ -132,6 +138,8 @@ RSpec.feature "Chords", type: :feature do
       expect(all(".c-chordunit__modifier")[0]).to have_content "m7"
       expect(all(".c-chordunit__leftbar")[0]).to have_content '"'
       expect(all(".c-chordunit__rightbar")[0]).to have_content "}"
+
+      expect(all(".c-chordunit__note-name")[1]).to have_content "E"
 
       expect(all(".c-chordunit__indicator")[$chordunit_num-1]).to have_content ""
       expect(all(".c-chordunit__repeat")[$chordunit_num-1]).to have_content ""
@@ -169,9 +177,9 @@ RSpec.feature "Chords", type: :feature do
     all(".c-chordunit")[$chordunit_num-1].click
     find(".p-chord-new__editor-btn").click
 
-    all(".c-chord-edit__btn")[19].click
-    all(".c-chord-edit__btn")[19].click
-    all(".c-chord-edit__btn")[19].click
+    all(".c-chord-edit__btn")[20].click
+    all(".c-chord-edit__btn")[20].click
+    all(".c-chord-edit__btn")[20].click
 
     all(".c-chord-edit__btn")[6].click
     all(".c-chord-edit__btn")[7].click
@@ -217,7 +225,7 @@ RSpec.feature "Chords", type: :feature do
     expect(all(".c-chordunit__note-name")[$chordunit_num-1]).to have_content "F"
     expect(all(".c-chordunit__half-note")[$chordunit_num-1]).to have_content "B"
     expect(all(".c-chordunit__modifier")[$chordunit_num-1]).to have_content ""
-    expect(all(".c-chordunit__rightbar")[47]).to have_content "}"
+    expect(all(".c-chordunit__rightbar")[$chordunit_num-1]).to have_content "}"
 
   end
 


### PR DESCRIPTION
## what
- コードエディターにchordunit送りキーを追加
- 上記のキーを押すと次のchordunitにカーソルが移動するjsを追加
- 変更点に合わせてchordモデルに関する統合テストの記述を修正

## why
- スマホでの操作性の向上