### PR TITLE
fix_display_error_about_second_score_in_song#show

### DIFF
--- a/app/assets/javascripts/chord.js
+++ b/app/assets/javascripts/chord.js
@@ -328,17 +328,20 @@ $(function () {
 
   $(document).ready(function () {
     $(".c-chordunit__wrapper").each(function (i, chordunit) {
-      cursor_display("unit_0-" + i);
       var letter = $(chordunit).find(".c-chordunit__text").attr("value");
 
       var chord_num = Math.floor(i / chordunit_num);
       var unit_num = i % chordunit_num;
 
+      cursor_display("unit_" + chord_num + "-" + unit_num);
+
       if (letter != undefined) {
         letter = letter.trim();
         text_display("unit_" + chord_num + "-" + unit_num, letter);
       }
+      console.log(i + "番目");
 
+      // ↓２つ目のコード譜の１つめのコードユニットでエラーが発生している
       // part_display
       var value_of_part = $(chordunit).find(".c-chordunit__part").text();
       if (value_of_part != "") {
@@ -348,6 +351,8 @@ $(function () {
           selected_html_append("part", i, part);
         });
       }
+      console.log(i + "番目");
+
       // repeat_display
       var value_of_repeat = $(chordunit).find(".c-chordunit__repeat").text();
       if (value_of_repeat != "") {
@@ -363,6 +368,7 @@ $(function () {
         default_input(i);
       }
     });
+
     $(".c-chordunit").removeClass("c-js__cursor");
   });
 

--- a/spec/features/songs_spec.rb
+++ b/spec/features/songs_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-      # save_and_open_page
 
 RSpec.feature "Songs", type: :feature do
   scenario "ユーザーが新しい楽曲データを登録する", js: true  do
@@ -162,6 +161,41 @@ RSpec.feature "Songs", type: :feature do
     all(".c-form__btn")[3].click
     expect(page).to have_content "Blue Ridge Cabin Home"
     expect(all(".p-search-result__result").size).to eq(1)
+  end
+
+  scenario "楽曲個別ページで1~3つ目のコード譜が正常に表示されている", js: true do
+    song = FactoryBot.create(:song, title: "Blue Ridge Cabin Home")
+
+    chord1 = FactoryBot.create(:chord, song_id: song.id)
+    ($chordunit_num).times do |i|
+      FactoryBot.create(:chordunit, address: i-1, chord_id: chord1.id)
+    end
+
+    chord2 = FactoryBot.create(:chord, song_id: song.id)
+    ($chordunit_num).times do |i|
+      FactoryBot.create(:chordunit, address: i-1, chord_id: chord2.id)
+    end
+
+    chord3 = FactoryBot.create(:chord, song_id: song.id)
+    ($chordunit_num).times do |i|
+      FactoryBot.create(:chordunit, address: i-1, chord_id: chord3.id)
+    end
+
+    visit "songs/#{song.id}"
+
+    song.chords.each_with_index do |chord, i|
+      total_index = $chordunit_num * (i)
+      expect(all(".c-chordunit__part")[total_index]).to have_content "Intro"
+      expect(all(".c-chordunit__part")[total_index]).to have_content "Solo"
+      expect(all(".c-chordunit__repeat")[total_index]).to have_content "3."
+      expect(all(".c-chordunit__indicator")[total_index]).to have_content "break"
+      expect(all(".c-chordunit__beat")[total_index]).to have_content "@"
+      expect(all(".c-chordunit__leftbar")[total_index]).to have_content "{"
+      expect(all(".c-chordunit__note-name")[total_index]).to have_content "G"
+      expect(all(".c-chordunit__half-note")[total_index]).to have_content "B"
+      expect(all(".c-chordunit__modifier")[total_index]).to have_content "m"
+      expect(all(".c-chordunit__rightbar")[total_index]).to have_content "}"
+    end
   end
 
 end


### PR DESCRIPTION
## what
- cursor_displayの引数を変更
- song#showビューで複数のコード譜が登録されている場合の表示テストを追加

## why
- 楽曲個別ページで発生しているエラーを修正