### PR TITLE
breadcrumbs_navigation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,10 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - test
+      - test:
+          filters:
+            branches:
+              igunore: master
       - build_and_push:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ workflows:
       - test:
           filters:
             branches:
-              igunore: master
+              ignore: master
       - build_and_push:
           requires:
             - test

--- a/Gemfile
+++ b/Gemfile
@@ -82,3 +82,4 @@ gem 'rails-i18n'
 gem 'unicorn', '5.5.5'
 gem 'recaptcha', require: "recaptcha/rails"
 gem 'kaminari'
+gem 'gretel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
       sassc (>= 1.11)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (4.0.1)
+      rails (>= 5.1)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -295,6 +297,7 @@ DEPENDENCIES
   devise
   factory_bot_rails
   font-awesome-sass
+  gretel
   haml-rails
   hirb
   hirb-unicode

--- a/app/assets/javascripts/chord.js
+++ b/app/assets/javascripts/chord.js
@@ -339,7 +339,6 @@ $(function () {
         letter = letter.trim();
         text_display("unit_" + chord_num + "-" + unit_num, letter);
       }
-      console.log(i + "番目");
 
       // ↓２つ目のコード譜の１つめのコードユニットでエラーが発生している
       // part_display
@@ -351,7 +350,6 @@ $(function () {
           selected_html_append("part", i, part);
         });
       }
-      console.log(i + "番目");
 
       // repeat_display
       var value_of_repeat = $(chordunit).find(".c-chordunit__repeat").text();

--- a/app/assets/javascripts/chord_change.js
+++ b/app/assets/javascripts/chord_change.js
@@ -134,7 +134,6 @@ $(function () {
     $(".c-chordunit__note").each(function (i, value) {
       var note = $(value).children(".c-chordunit__note-name").text();
       note = note + $(value).children(".c-chordunit__half-note").text();
-      console.log(note);
 
       // 異常表記または別表記を変換する
       if (note == "Ab") {

--- a/app/assets/javascripts/recaptcha.js
+++ b/app/assets/javascripts/recaptcha.js
@@ -1,15 +1,12 @@
 $(function () {
   $("#new_user").on("submit", function (e) {
     e.preventDefault();
-    console.log("hakka");
     grecaptcha.ready(function () {
       grecaptcha
         .execute("6LdDibUZAAAAAB3YKCwEDjWuSwzOM86evQRvjWah", {
           action: "submit",
         })
         .then(function (token) {
-          console.log(token);
-
           // Add your logic to submit to your backend server here.
           $(".c-js__recaptcha-token").val(token);
           // フォーム送信

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,6 +13,7 @@
 @import "layout/_footer";
 
 // component
+@import "object/component/breadcrumbs";
 @import "object/component/chord-edit";
 @import "object/component/chordunit";
 @import "object/component/font";

--- a/app/assets/stylesheets/object/component/_breadcrumbs.scss
+++ b/app/assets/stylesheets/object/component/_breadcrumbs.scss
@@ -1,0 +1,13 @@
+.c-breadcrumbs {
+  width: 100%;
+}
+
+.c-breadcrumbs__list {
+  color: $color-theme-red;
+  & span {
+    color: $color-font-black;
+  }
+  & a {
+    color: $color-theme-red;
+  }
+}

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -65,7 +65,13 @@ class SongsController < ApplicationController
     @songs = Song.all.includes(:chords)
     @songs = @songs.order("title asc")
 
-    exchange_global_params
+
+    params[:jam] = params[:jam_global]
+    params[:standard] = params[:standard_global]
+    params[:beginner] = params[:beginner_global]
+    params[:vocal] = params[:vocal_global]
+    params[:instrumental] = params[:instrumental_global]
+
     search_song
 
     @count = @songs.length
@@ -80,10 +86,6 @@ class SongsController < ApplicationController
   def id_search
     # set_songアクションを用いて楽曲レコード取得
   end
-
-  end
-
-
   private
     def set_song
       @song = Song.find(params[:id])
@@ -114,11 +116,5 @@ class SongsController < ApplicationController
       end
     end
 
-    def exchange_global_params
-      params[:jam] = params[:jam_global]
-      params[:standard] = params[:standard_global]
-      params[:beginner] = params[:beginner_global]
-      params[:vocal] = params[:vocal_global]
-      params[:instrumental] = params[:instrumental_global]
-    end
+  end
 end

--- a/app/views/application/_breadcrumbs.html.haml
+++ b/app/views/application/_breadcrumbs.html.haml
@@ -1,0 +1,2 @@
+.c-breadcrumbs{class: "c-breadcrumbs__#{layout}"}
+  = breadcrumbs pretext: "",separator: " &rsaquo; ", class: "c-breadcrumbs__list"

--- a/app/views/chords/edit.html.haml
+++ b/app/views/chords/edit.html.haml
@@ -41,6 +41,8 @@
         =render "/application/chordunit-form", f: f
     .content__registration
       =f.submit "登録", class:"c-form__btn c-form__btn--registration"
+    - breadcrumb :chord_edit
+    = render "application/breadcrumbs", layout: "footer"
     .p-chord-new__editor-btn
       >> Editor
 =render "/application/chord-editor"

--- a/app/views/chords/new.html.haml
+++ b/app/views/chords/new.html.haml
@@ -37,6 +37,8 @@
         =render "/application/chordunit-form", f: f
     .content__registration
       =f.submit "登録", class:"c-form__btn c-form__btn--registration"
+    - breadcrumb :chord_new
+    = render "application/breadcrumbs", layout: "footer"
     .p-chord-new__editor-btn
       >> Editor
-=render "/application/chord-editor"
+= render "/application/chord-editor"

--- a/app/views/chords/show.html.haml
+++ b/app/views/chords/show.html.haml
@@ -40,5 +40,7 @@
       %a
         |
       =link_to "Delete", chord_path, method: :delete, data: { confirm: "本当によろしいですか？" }
-  .p-chord__return
-    =link_to "コード譜一覧に戻る", song_path(@chord.song)
+  -# .p-chord__return
+  -#   =link_to "コード譜一覧に戻る", song_path(@chord.song)
+  - breadcrumb :chord_show
+  = render "application/breadcrumbs", layout: "footer"

--- a/app/views/songs/edit.html.haml
+++ b/app/views/songs/edit.html.haml
@@ -14,3 +14,6 @@
           =f.submit "登録", class:"c-form__btn c-form__btn--login"
     %figure
       =image_tag "/images/banjo.png", class: "c-section__image-banjo"
+  - breadcrumb :song_edit
+  = render "application/breadcrumbs", layout: "footer"
+

--- a/app/views/songs/new.html.haml
+++ b/app/views/songs/new.html.haml
@@ -14,3 +14,5 @@
           =f.submit "登録", class:"c-form__btn c-form__btn--login"
     %figure
       =image_tag "/images/banjo.png", class: "c-section__image-banjo"
+  - breadcrumb :song_new
+  = render "application/breadcrumbs", layout: "footer"

--- a/app/views/songs/show.html.haml
+++ b/app/views/songs/show.html.haml
@@ -73,5 +73,5 @@
         %hr
   - else
     %section.c-window__skeleton.p-song__notice この楽曲には、コード譜が登録されていません
-
-  -# .c-chordunit__wrapper--large
+  - breadcrumb :song_show
+  = render "application/breadcrumbs", layout: "footer"

--- a/app/views/users/registrations/edit.html.haml
+++ b/app/views/users/registrations/edit.html.haml
@@ -21,3 +21,5 @@
         = button_to "ユーザを削除する", registration_path(resource_name), data: { confirm: "二度と復旧できません。本当によろしいですか？" }, method: :delete, class:"c-form__btn c-form__btn-blue"
     %figure
       =image_tag "/images/fiddle.png", class: "c-section__image-fiddle"
+  - breadcrumb :user_edit
+  = render "application/breadcrumbs", layout: "footer"

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -21,3 +21,5 @@
           =f.submit "登録", class:"c-form__btn c-form__btn--login c-js__recaptcha"
     %figure
       =image_tag "/images/fiddle.png", class: "c-section__image-fiddle"
+  - breadcrumb :sign_up
+  = render "application/breadcrumbs", layout: "footer"

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -24,3 +24,5 @@
               =link_to "お試しログイン", users_test_sign_in_path
     %figure
       =image_tag "/images/fiddle.png", class: "c-section__image-fiddle"
+  - breadcrumb :sign_in
+  = render "application/breadcrumbs", layout: "footer"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -32,7 +32,7 @@
         .c-review__text コード譜の信頼数
       .p-user__edit
         - if current_user.id == @user.id
-          =link_to "Edit", edit_user_registration_path
+          =link_to "Edit", edit_user_registration_path(id: @user.id)
   %section.c-section__sentence-box.p-user__section
     .p-user__section-header
       .p-user__icon--user
@@ -51,9 +51,5 @@
                 = link_to "リストから削除する", practice_path(practice, chord_id: practice.chord.id), method: :delete, remote: true
       -else
         ="練習曲に登録している楽曲がありません"
-
-
-
-
-
-
+  - breadcrumb :user_show
+  = render "application/breadcrumbs", layout: "footer"

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,87 @@
+crumb :root do
+  link "Home", root_path
+end
+
+crumb :sign_in do
+  link "ログイン", new_user_session_path
+  parent :root
+end
+
+crumb :sign_up do
+  link "ユーザ登録", new_user_registration_path
+  parent :root
+end
+
+crumb :user_show do
+  link "マイページ", user_path(params[:id])
+  parent :root
+end
+
+crumb :user_edit do
+  link "ユーザ情報の編集", edit_user_registration_path
+  parent :user_show
+end
+
+crumb :song_search do
+  link "検索", search_songs_path(keyword: "")
+  parent :root
+end
+
+crumb :song_new do
+  link "楽曲の登録", new_song_path
+  parent :root
+end
+
+crumb :song_show do |song|
+  if song == nil
+    song = Song.find(params[:id])
+  end
+  link song.title, song_path(song)
+  parent :song_search
+end
+
+crumb :song_edit do
+  link "楽曲の編集", edit_song_path
+  parent :song_show
+end
+
+crumb :chord_new do
+  link "コード譜の作成", new_chord_path
+  parent :root
+end
+
+crumb :chord_show do
+  chord = Chord.find(params[:id])
+  link "コード譜", chord_path
+  parent :song_show, chord.song
+end
+
+crumb :chord_edit do
+  link "コード譜の編集", edit_chord_path
+  parent :chord_show
+end
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).

--- a/spec/features/applications_spec.rb
+++ b/spec/features/applications_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.feature "applications", type: :feature do
+  it "パンくずの表示確認" do
+    user = FactoryBot.create(:user)
+    song = FactoryBot.create(:song, user_id: user.id)
+    chord = FactoryBot.create(:chord, user_id: user.id, song_id: song.id)
+
+    visit new_user_session_path
+    expect(find(".c-breadcrumbs")).to have_content "Home"
+    expect(find(".c-breadcrumbs")).to have_content "ログイン"
+
+    visit new_user_registration_path
+    expect(find(".c-breadcrumbs")).to have_content "Home"
+    expect(find(".c-breadcrumbs")).to have_content "ユーザ登録"
+
+    login_as(user)
+
+    visit user_path(user.id)
+    expect(find(".c-breadcrumbs")).to have_content "Home"
+    expect(find(".c-breadcrumbs")).to have_content "マイページ"
+
+    visit edit_user_registration_path(id: user.id)
+    expect(find(".c-breadcrumbs")).to have_content "Home"
+    expect(find(".c-breadcrumbs")).to have_content "マイページ"
+    expect(find(".c-breadcrumbs")).to have_content "ユーザ情報の編集"
+
+    visit new_song_path
+    expect(find(".c-breadcrumbs")).to have_content "Home"
+    expect(find(".c-breadcrumbs")).to have_content "楽曲の登録"
+
+    visit song_path(song)
+    expect(find(".c-breadcrumbs")).to have_content "Home"
+    expect(find(".c-breadcrumbs")).to have_content "検索"
+    expect(find(".c-breadcrumbs")).to have_content song.title
+
+    visit edit_song_path(song)
+    expect(find(".c-breadcrumbs")).to have_content "Home"
+    expect(find(".c-breadcrumbs")).to have_content "検索"
+    expect(find(".c-breadcrumbs")).to have_content song.title
+    expect(find(".c-breadcrumbs")).to have_content "楽曲の編集"
+
+    visit new_chord_path
+    expect(find(".c-breadcrumbs")).to have_content "Home"
+    expect(find(".c-breadcrumbs")).to have_content "コード譜の作成"
+
+    visit chord_path(chord)
+    expect(find(".c-breadcrumbs")).to have_content "Home"
+    expect(find(".c-breadcrumbs")).to have_content "検索"
+    expect(find(".c-breadcrumbs")).to have_content song.title
+    expect(find(".c-breadcrumbs")).to have_content "コード譜"
+
+    visit edit_chord_path(chord)
+    expect(find(".c-breadcrumbs")).to have_content "Home"
+    expect(find(".c-breadcrumbs")).to have_content "検索"
+    expect(find(".c-breadcrumbs")).to have_content song.title
+    expect(find(".c-breadcrumbs")).to have_content "コード譜"
+    expect(find(".c-breadcrumbs")).to have_content "コード譜の編集"
+  end
+end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -112,12 +112,12 @@ RSpec.feature "Users", type: :feature do
 
     click_button "登録"
 
-    expect(page).to have_current_path(edit_user_registration_path)
+    expect(page).to have_current_path(edit_user_registration_path(id: user.id))
     expect(page).to have_content "テストユーザーは編集できません"
 
     click_button "ユーザを削除する"
 
-    expect(page).to have_current_path(edit_user_registration_path)
+    expect(page).to have_current_path(edit_user_registration_path(id: user.id))
     expect(page).to have_content "テストユーザーは編集できません"
   }.to change(User, :count).by(0)
   end


### PR DESCRIPTION
## what
- gem 'gretel'をインストール
- 設定ファイルconfig/breadcrumbs.rbの記述
- トップページと検索画面を除く各viewにパンくずリストを表示するための記述を追加

## why
- パンくずナビゲーションの追加によるUI改善、SEO対策