### PR TITLE
fix_code_getting_unit_id

### DIFF
--- a/app/assets/javascripts/chord.js
+++ b/app/assets/javascripts/chord.js
@@ -329,18 +329,13 @@ $(function () {
   $(document).ready(function () {
     $(".c-chordunit__wrapper").each(function (i, chordunit) {
       var letter = $(chordunit).find(".c-chordunit__text").attr("value");
+      var unit_id = $(chordunit).find(".c-chordunit").attr("id");
 
-      var chord_num = Math.floor(i / chordunit_num);
-      var unit_num = i % chordunit_num;
-
-      cursor_display("unit_" + chord_num + "-" + unit_num);
-
-      // 本番環境のでバッグ用
-      console.log("unit_" + chord_num + "-" + unit_num);
+      cursor_display(unit_id);
 
       if (letter != undefined) {
         letter = letter.trim();
-        text_display("unit_" + chord_num + "-" + unit_num, letter);
+        text_display(unit_id, letter);
       }
 
       // part_display


### PR DESCRIPTION
## what
- chordunitのunit_idの取得の手法を変更

## why
下記条件で発生する表示エラーの修正
- 楽曲に登録された2つ目以降のコード譜
- 1コード譜あたりのchordunit数が48個仕様のときに登録されたコード譜
→chordunit数(定数=72)を元に表示jsの動作対象となるunit_idを決定していた
→ビューから直接unit_idを取得する手法に変更