### PR TITLE
add_searching_user_function

### DIFF
--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -8,8 +8,8 @@ $(function () {
   $(".c-js__song-candidate").on("keyup", function () {
     var input = $(this).val();
     $(".c-song-candidate__lists").addClass("u-display__hidden");
-
     if (input == "") {
+      $("#selected_song_id").val("");
       return;
     }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -36,6 +36,7 @@
 @import "object/project/global-search";
 @import "object/project/navi";
 @import "object/project/search-result";
+@import "object/project/search-user";
 @import "object/project/song";
 @import "object/project/top";
 @import "object/project/user"; // utility

--- a/app/assets/stylesheets/object/component/_form.scss
+++ b/app/assets/stylesheets/object/component/_form.scss
@@ -65,6 +65,7 @@
   position: relative;
   display: flex;
   align-items: center;
+  margin-left: auto;
 }
 
 .c-form__btn {

--- a/app/assets/stylesheets/object/component/_song-candidate.scss
+++ b/app/assets/stylesheets/object/component/_song-candidate.scss
@@ -1,5 +1,6 @@
 .c-song-candidate__wrapper {
   position: relative;
+  width: 100%;
 }
 
 .c-song-candidate__lists {

--- a/app/assets/stylesheets/object/project/_search-user.scss
+++ b/app/assets/stylesheets/object/project/_search-user.scss
@@ -1,0 +1,12 @@
+.p-search-user__result {
+  background: linear-gradient(
+    180deg,
+    #a64951 0%,
+    #a64951 35px,
+    #d9d0c7 35px,
+    #d9d0c7 100%
+  );
+}
+.p-search-user__name {
+  color: $color-font-white;
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,20 @@ class UsersController < ApplicationController
     @practices = @user.practices.includes(:chord)
   end
 
+  def search
+    @users = User.all
+    if params[:song_id].present?
+      @song = Song.find(params[:song_id])
+      @users = []
+      @song.chords.each do |chord|
+        chord.practices.each do |practice|
+          @users << practice.user
+        end
+      end
+    end
+
+  end
+
   private
   def set_user
     @user = User.find(params[:id])

--- a/app/views/application/_search_user.html.haml
+++ b/app/views/application/_search_user.html.haml
@@ -1,0 +1,11 @@
+.c-form__search-box
+  .c-song-candidate__wrapper
+    .c-song-candidate__form
+      =f.text_field :song_name, value: (@song.title if @song), autocomplete:"off", id: "search_song_name", placeholder: "曲名",class: "c-form__textbox c-js__song-candidate"
+      =f.text_field :song_id, value: (@song.id if @song), id: "selected_song_id", class: "u-display__hidden"
+    .c-song-candidate__lists.c-window__clear-black.u-display__hidden
+  =f.label :search, class:"c-search__send-btn c-form__position--box-btn" do
+    .c-form__btn
+    %i.fas.fa-search.c-form__btn-icon
+    =f.submit "", class: "c-form__btn u-color__skeleton-cover"
+

--- a/app/views/layouts/_navi.html.haml
+++ b/app/views/layouts/_navi.html.haml
@@ -38,12 +38,19 @@
               %i.fas.fa-user-plus
             %span.p-navi__string__parent
               =link_to "ユーザ登録", new_user_registration_path
+    -# .p-navi__content.c-js__menu__fade-in
+    -#   .p-navi__content__parent
+    -#     .p-navi__link-btn--parent
+    -#       .p-navi__icon-box
+    -#         %i.far.fa-file-pdf
+    -#       %span.p-navi__string__parent コード表 作成
     .p-navi__content.c-js__menu__fade-in
-      .p-navi__content__parent
+      .p-navi__content__parent.p-navi__btn-pulldown
         .p-navi__link-btn--parent
           .p-navi__icon-box
-            %i.far.fa-file-pdf
-          %span.p-navi__string__parent コード表 作成
+            %i.far.fa-address-book
+          %span.p-navi__string__parent
+            =link_to "ユーザ検索", search_users_path
     - if user_signed_in?
       .p-navi__content.c-js__menu__fade-in
         .p-navi__content__parent
@@ -52,5 +59,6 @@
               %i.fas.fa-sign-out-alt
             %span.p-navi__string__parent
               =link_to "ログアウト", destroy_user_session_path, method: :delete
+
   .c-layer__black
     .c-layer__black-sub

--- a/app/views/users/search.html.haml
+++ b/app/views/users/search.html.haml
@@ -1,0 +1,26 @@
+.p-search-result__wrapper
+%article.p-search-result__article
+  %section.p-search-result__section.c-window__clear
+    .c-search__title 練習している曲から探す
+    =form_with  url: search_users_path, method: :get, local: true do |f|
+      =render "application/search_user", f: f
+    %hr{color: "black", size: "1px"}
+    .p-search-result__results
+      -if @users.present?
+        - @users.each do |user|
+          =link_to user_path(user) do
+            .p-search-result__result.p-search-user__result
+              .p-search-user__name
+                =user.name
+              .u-space__bottom-10px
+              .p-user__info-list
+                .p-user__info-item 活動拠点：
+                .p-user__info-dat
+                  - if user.place.present?
+                    =user.place
+                  - else
+                    (登録なし)
+      - else
+        ユーザーが見つかりませんでした
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,11 @@ Rails.application.routes.draw do
   devise_scope :user do
     get "users/test_sign_in", to: "users/sessions#test_create"
   end
-  resources :users, only: :show
+  resources :users, only: :show do
+    collection do
+      get :search
+    end
+  end
   resources :songs, except: :index do
     collection do
       get :search

--- a/spec/controllers/songs_controller_spec.rb
+++ b/spec/controllers/songs_controller_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe SongsController, type: :controller do
       expect(response).to have_http_status "200"
     end
   end
-  describe "#search"
   describe "#create" do
     before do
       @user = FactoryBot.create(:user)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -14,4 +14,15 @@ RSpec.describe UsersController, type: :controller do
       expect(response).to have_http_status "200"
     end
   end
+
+  describe "#search" do
+    it "正常にレスポンスを返すこと" do
+      get :search
+      expect(response).to be_success
+    end
+    it "200レスポンスを返すこと" do
+      get :search
+      expect(response).to have_http_status "200"
+    end
+  end
 end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -129,4 +129,31 @@ RSpec.feature "Users", type: :feature do
 
     expect(page).to have_content "ユーザ登録"
   end
+
+  context "ユーザ検索" do
+    before do
+      @song = FactoryBot.create(:song, title: "Blue Ridge Cabin Home")
+      chord = FactoryBot.create(:chord, song_id: @song.id)
+      @user = FactoryBot.create(:user)
+      practice = FactoryBot.create(:practice, chord_id: chord.id, user_id: @user.id)
+    end
+    scenario "練習している曲名から探す", js: true do
+      visit root_path
+
+      # グローバルナビを開く
+      find(".l-header__opn-box").click
+
+      click_link "ユーザ検索"
+      fill_in "曲名", with: "b"
+
+      expect(page).to have_content("Blue Ridge Cabin Home")
+        # 楽曲の選択
+      all(".c-song-candidate__list")[0].click
+      all(".c-form__btn")[1].click
+
+      expect(page).to have_content(@user.name)
+      expect(page).to have_content(@user.place)
+
+    end
+  end
 end


### PR DESCRIPTION
## what
- user検索機能を追加
- 練習している楽曲からuser検索を実施できる機能を追加
- user検索機能のコントローラテスト、及び統合テスト

## why
- ユーザーは同じ嗜好を持つセッション仲間を見つけることができる
- 今後の拡張のためのベースになる機能

## coming soon
- 簡易チャット機能: 嗜好が似通ったジャム仲間と繋がることができる
- 活動地域から検索: 都道府県、地域別に検索することで近くのジャム仲間を見つけることができる
- (未定)複数楽曲検索: 趣味嗜好が近いジャム仲間をより高精度で調査することができる