### PR TITLE
update_user_information_wo_password

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -24,6 +24,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
     json_response = get_recaptcha_response(params[:user][:token])
 
     if json_response["success"] && json_response["score"] > judge_bot_score
+
+      # 既に登録済みのユーザ情報でエラー発生しないようカラム追加時にデフォルト設定を行った
+      # 活動拠点の未登録ユーザがいなくなった時点で下記を削除すること
       params[:user][:place_id] = 0 if params[:user][:place_id] == ""
       @user = User.new(user_params)
       if @user.save
@@ -50,11 +53,33 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # PUT /resource
   def update
+    # 既に登録済みのユーザ情報でエラー発生しないようカラム追加時にデフォルト設定を行った
+    # 活動拠点の未登録ユーザがいなくなった時点で下記を削除すること
     params[:user][:place_id] = 0 if params[:user][:place_id] == ""
     # because breadcrumb function needs "params[:id]"
     params[:id] = current_user.id
 
-    super
+    if params[:user][:password].present? && params[:user][:password_confirmation].present? && params[:user][:current_password].blank?
+      redirect_to edit_user_registration_path(id: current_user.id), notice: "パスワードを変更する際は、現在のパスワードを入力してください" and return
+    end
+
+    self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
+    prev_unconfirmed_email = resource.unconfirmed_email if resource.respond_to?(:unconfirmed_email)
+
+    #if update_resource(resource, account_update_params)
+    if resource.update_without_current_password(account_update_params)
+      yield resource if block_given?
+      if is_flashing_format?
+        flash_key = update_needs_confirmation?(resource, prev_unconfirmed_email) ?
+          :update_needs_confirmation : :updated
+        set_flash_message :notice, flash_key
+      end
+      sign_in resource_name, resource, :bypass => true
+      respond_with resource, :location => after_update_path_for(resource)
+    else
+      clean_up_passwords resource
+      respond_with resource
+    end
   end
 
   # DELETE /resource
@@ -101,6 +126,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
       redirect_back fallback_location: root_path, notice: 'テストユーザーは編集できません'
     end
   end
+
+  # def update_resource(resource, params)
+
+  #   resource.update_without_current_password(params)
+  # end
 
   # The path used after sign up for inactive accounts.
   # def after_inactive_sign_up_path_for(resource)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,17 @@ class User < ApplicationRecord
     self.find_by(id: "0")
   end
 
+  def update_without_current_password(params, *options)
+    params.delete(:current_password)
+    if params[:password].blank? && params[:password_confirmation].blank?
 
+      params.delete(:password)
+      params.delete(:password_confirmation)
+    end
 
+    result = update_attributes(params, *options)
+    clean_up_passwords
+
+    result
+  end
 end

--- a/app/views/users/registrations/edit.html.haml
+++ b/app/views/users/registrations/edit.html.haml
@@ -13,6 +13,7 @@
           %a 6文字以上
           =f.password_field :password, autocomplete: "new-password", placeholder: "新しいパスワード", class:"c-form__textbox c-user__textbox"
           =f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "新しいパスワード(確認)", class:"c-form__textbox c-user__textbox"
+          %a パスワードを変更する際は現在のパスワードを入力してください
           =f.password_field :current_password, autocomplete: "current-password", placeholder: "現在のパスワード", class:"c-form__textbox c-user__textbox"
         .c-form__area
           =f.submit "登録", class:"c-form__btn c-form__btn--login"

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -145,6 +145,116 @@ RSpec.feature "Users", type: :feature do
     }.to change(User, :count).by(-1)
   end
 
+  context "ユーザー情報の更新に成功する" do
+    before do
+      @user = FactoryBot.create(:user, password: "Old Password")
+    end
+    scenario "password以外の情報を変更し、現在のパスワードを入力しない" do
+      login_as(@user)
+      visit root_path
+
+      click_link "マイページ"
+      click_link "Edit"
+
+      fill_in "名前", with: "New Name"
+      click_button "登録"
+
+      expect(page).to have_current_path(root_path)
+      expect(page).to have_content "アカウントが更新されました"
+
+      click_link "マイページ"
+
+      expect(page).to have_content "New Name"
+    end
+    scenario "password以外の情報とpasswordを変更し、確認用パスワードと現在のパスワードを入力する" do
+      login_as(@user)
+      visit root_path
+
+      click_link "マイページ"
+      click_link "Edit"
+
+      fill_in "名前", with: "New Name"
+      fill_in "新しいパスワード", with: "New Password"
+      fill_in "新しいパスワード(確認)", with: "New Password"
+      fill_in "現在のパスワード", with: @user.password
+
+      click_button "登録"
+
+      expect(page).to have_current_path(root_path)
+      expect(page).to have_content "アカウントが更新されました"
+
+      click_link "マイページ"
+
+      expect(page).to have_content "New Name"
+    end
+  end
+  context "ユーザー情報の更新に失敗する" do
+    before do
+      @user = FactoryBot.create(:user, password: "Old Password")
+    end
+    scenario "password以外の情報とpasswordを変更し、確認用パスワードを入力するが現在のパスワードを入力しないredirect" do
+      login_as(@user)
+      visit root_path
+
+      click_link "マイページ"
+      click_link "Edit"
+
+      fill_in "名前", with: "New Name"
+      fill_in "新しいパスワード", with: "New Password"
+      fill_in "新しいパスワード(確認)", with: "New Password"
+
+      click_button "登録"
+
+      expect(page).to have_current_path(edit_user_registration_path(id: @user.id))
+      expect(page).to have_content "パスワードを変更する際は、現在のパスワードを入力してください"
+
+      visit root_path
+      click_link "マイページ"
+
+      expect(page).to have_content @user.name
+    end
+    scenario "passwordを変更し、現在のパスワードを入力するが、確認用パスワードを入力しない" do
+      login_as(@user)
+      visit root_path
+
+      click_link "マイページ"
+      click_link "Edit"
+
+      fill_in "名前", with: "New Name"
+      fill_in "新しいパスワード", with: "New Password"
+      fill_in "現在のパスワード", with: @user.password
+
+      click_button "登録"
+
+      expect(page).to have_current_path("/users")
+
+      visit root_path
+      click_link "マイページ"
+
+      expect(page).to have_content @user.name
+    end
+    scenario "確認用パスワードを入力し、現在のパスワードを入力するが、passwordを変更しない" do
+      login_as(@user)
+      visit root_path
+
+      click_link "マイページ"
+      click_link "Edit"
+
+      fill_in "名前", with: "New Name"
+      fill_in "新しいパスワード(確認)", with: "New Password"
+      fill_in "現在のパスワード", with: @user.password
+
+      click_button "登録"
+
+      expect(page).to have_current_path("/users")
+
+      visit root_path
+      click_link "マイページ"
+
+      expect(page).to have_content @user.name
+    end
+  end
+
   scenario "テストユーザーはユーザー情報を編集することも削除することもできない" do
     user = FactoryBot.create(:user, id: 0)
 


### PR DESCRIPTION
## what
- 現在のパスワードの入力なしでユーザ情報を変更できる仕様に変更
- パスワードを変更する際は、現在のパスワードの入力を必要とする仕様とした

## why
- ユーザ情報の変更のたびにパスワードを求める仕様ではユーザフレンドリでない上、操作が直感的ではない