### PR TITLE
install_sass_gem_for_rails6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,7 @@ RUN apk update && \
     find /usr/lib/node_modules -delete && \
     find /usr/local/bundle/gems/ -name "*.c" -delete && \
     find /usr/local/bundle/gems/ -name "*.o" -delete && \
-    apk del --purge libxml2-dev curl-dev make gcc libc-dev g++ linux-headers && \
-    bundle exec rails assets:precompile RAILS_ENV=production
+    apk del --purge libxml2-dev curl-dev make gcc libc-dev g++ linux-headers
 
 COPY . /grasschords
 RUN chmod +x start.sh

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'mysql2', '>= 0.4.4', '< 0.6.0'
 # Use haml for view files
 gem 'haml-rails'
 # Use SCSS for stylesheets
-gem 'sass-rails', '>=2.1.2'
+gem 'sassc-rails', '>=2.1.2'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,19 +227,14 @@ GEM
     ruby_parser (3.14.2)
       sexp_processor (~> 4.9)
     rubyzip (2.3.0)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.1.0)
-      railties (>= 5.2.0)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
     sassc (2.3.0)
       ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -315,7 +310,7 @@ DEPENDENCIES
   rails-i18n (= 6.0.0)
   recaptcha
   rspec-rails (~> 3.6.0)
-  sass-rails (>= 2.1.2)
+  sassc-rails (>= 2.1.2)
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# bundle exec rails webpacker:compile RAILS_ENV=production
+bundle exec rails assets:precompile RAILS_ENV=production
 bundle exec rails db:create RAILS_ENV=production
 bundle exec rails db:migrate RAILS_ENV=production
 bundle exec unicorn -p 3000 -c /grasschords/config/unicorn.rb -E production


### PR DESCRIPTION
## what
- プリコンパイル実行をdockerfileではなく、コンテナ実行shファイルに移行
- sass-railsをrails6推奨のsassコンパイルgem sassc-railsに変更

## why
- 本番環境エラー修正